### PR TITLE
also protect and log in the other place that errors

### DIFF
--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -15,9 +15,6 @@ module Rack
 
         class << env
           (Hash.instance_methods.reject { |i| i =~ /^__|\?$/ } - SKIP).each do |m|
-
-            define_method(m.to_s.sub(/(?=[!=]?$)/, "_without_hijack")) { |*a,&b| Hash.instance_method(m).bind(self).call *a,&b }
-
             define_method m do |*a,&b|
               has_rt_info_before = member? "rack-timeout.info" # Rack::Timeout::ENV_INFO_KEY
               result = super *a,&b
@@ -29,7 +26,6 @@ module Rack
               end
               return result
             end
-
           end
 
           def req_id

--- a/lib/rack/timeout/logging-observer.rb
+++ b/lib/rack/timeout/logging-observer.rb
@@ -38,6 +38,10 @@ class Rack::Timeout::StateChangeLoggingObserver
   # generates the actual log string
   def log_state_change(env)
     info = env[::Rack::Timeout::ENV_INFO_KEY]
+    if info.nil?
+      Rails.logger.warn "source=rack-timeout-debug info-vanish id=#{env.respond_to?(:req_id) ? env.req_id : env["HTTP_X_REQUEST_ID"]}\n"
+      return
+    end
     level = STATE_LOG_LEVEL[info.state]
     logger(env).send(level) do
       s  = "source=rack-timeout"


### PR DESCRIPTION
/domain @dschaub 

I'm also killing off the `define_method` for the `_without_hijack` methods because that's not actually in use anywhere.
